### PR TITLE
Check if image is a link

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,10 @@ function checkAltText(ast, file) {
         file.message(altText(node.alt), node);
       }
       if (imageIsLink && hasAltText) {
-        file.message("Alt text should describe the link, not the image.", node);
+        file.message(
+          "Images inside a link tag require alt text that describes the purpose of the link.",
+          node
+        );
       }
     });
   });

--- a/index.js
+++ b/index.js
@@ -7,9 +7,17 @@ const altText = require("@double-great/alt-text");
 function checkAltText(ast, file) {
   const textToNodes = {};
   let imageIsLink = false;
+  let hasAltText = false;
   const aggregate = node => {
     const alt = node.alt || undefined;
-    if (!alt) return;
+    if (alt) hasAltText = true;
+    if (!alt && !imageIsLink) return;
+    if (!alt && imageIsLink) {
+      file.message(
+        "An image link should have alt text to describe the link.",
+        node
+      );
+    }
     if (!textToNodes[alt]) {
       textToNodes[alt] = [];
     }
@@ -31,7 +39,7 @@ function checkAltText(ast, file) {
       if (node.alt && altText(node.alt)) {
         file.message(altText(node.alt), node);
       }
-      if (imageIsLink) {
+      if (imageIsLink && hasAltText) {
         file.message("Alt text should describe the link, not the image.", node);
       }
     });

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function checkAltText(ast, file) {
     if (!alt && !imageIsLink) return;
     if (!alt && imageIsLink) {
       file.message(
-        "An image link should have alt text to describe the link.",
+        "No alt text found: Images inside a link tag require alt text that describes the purpose of the link.",
         node
       );
     }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "@double-great/alt-text": "^0.1.0",
     "unified-lint-rule": "^1.0.4",
-    "unist-util-visit": "^2.0.1"
+    "unist-util-visit": "^2.0.1",
+    "unist-util-visit-parents": "^3.0.1"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.3",

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -48,7 +48,7 @@ test("Image is a link, should have alt text", assert => {
     assert.equal(vFile.messages.length, 1);
     assert.equal(
       vFile.messages[0].reason,
-      "Not alt text found: Images inside a link tag require alt text that describes the purpose of the link."
+      "No alt text found: Images inside a link tag require alt text that describes the purpose of the link."
     );
     assert.end();
   });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -34,7 +34,7 @@ test("Image is a link", assert => {
     assert.equal(vFile.messages.length, 1);
     assert.equal(
       vFile.messages[0].reason,
-      "Alt text should describe the link, not the image."
+      "Images inside a link tag require alt text that describes the purpose of the link."
     );
     assert.end();
   });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -40,6 +40,20 @@ test("Image is a link", assert => {
   });
 });
 
+test("Image is a link, should have alt text", assert => {
+  const lint = processMarkdown(dedent`
+      [![](https://site.com/image.png)](https://website.org)
+    `);
+  return lint.then(vFile => {
+    assert.equal(vFile.messages.length, 1);
+    assert.equal(
+      vFile.messages[0].reason,
+      "An image link should have alt text to describe the link."
+    );
+    assert.end();
+  });
+});
+
 test("No warnings", assert => {
   const lint = processMarkdown(dedent`
       # Title of my site

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -26,6 +26,20 @@ test("End in period", assert => {
   });
 });
 
+test("Image is a link", assert => {
+  const lint = processMarkdown(dedent`
+      [![Puppies.](https://site.com/image.png)](https://website.org)
+    `);
+  return lint.then(vFile => {
+    assert.equal(vFile.messages.length, 1);
+    assert.equal(
+      vFile.messages[0].reason,
+      "Alt text should describe the link, not the image."
+    );
+    assert.end();
+  });
+});
+
 test("No warnings", assert => {
   const lint = processMarkdown(dedent`
       # Title of my site

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -48,7 +48,7 @@ test("Image is a link, should have alt text", assert => {
     assert.equal(vFile.messages.length, 1);
     assert.equal(
       vFile.messages[0].reason,
-      "An image link should have alt text to describe the link."
+      "Not alt text found: Images inside a link tag require alt text that describes the purpose of the link."
     );
     assert.end();
   });


### PR DESCRIPTION
If an ancestor of the link is an image, send a warning that the alt text should describe the link, not the image.